### PR TITLE
Adjust namespaces and update docs

### DIFF
--- a/RegraNegocio/App/Rules/TRecordRN.php
+++ b/RegraNegocio/App/Rules/TRecordRN.php
@@ -3,12 +3,12 @@ namespace Genesis\RegraNegocio\App\Rules;
 
 use Genesis\RegraNegocio\IRegraNegocio;
 use Psr\Log\LoggerInterface;
-use Genesis\RegraNegocio\Helpers\LoggerHelper;
+use Genesis\RegraNegocio\Helpers\TraitLogRN;
 use Genesis\RegraNegocio\TRecord;
 
 class TRecordRN implements IRegraNegocio
 {
-    use LoggerHelper;
+    use TraitLogRN;
 
     private array $params = [];
     private mixed $results = null;

--- a/RegraNegocio/App/Rules/ValidadorFinanceiro.php
+++ b/RegraNegocio/App/Rules/ValidadorFinanceiro.php
@@ -1,11 +1,11 @@
 <?php
-namespace App\Rules;
+namespace Genesis\RegraNegocio\App\Rules;
 
-use Genesis\Contracts\BusinessRuleInterface;
-use Genesis\Contracts\LoggableInterface;
+use Genesis\RegraNegocio\IRegraNegocio;
+use Genesis\RegraNegocio\ILog;
 use Psr\Log\LoggerInterface;
 
-class ValidadorFinanceiro implements BusinessRuleInterface, LoggableInterface
+class ValidadorFinanceiro implements IRegraNegocio, ILog
 {
     private array $params = [];
     private LoggerInterface $logger;

--- a/RegraNegocio/Helpers/TraitLogRN.php
+++ b/RegraNegocio/Helpers/TraitLogRN.php
@@ -1,9 +1,9 @@
 <?php
-namespace Helpers;
+namespace Genesis\RegraNegocio\Helpers;
 
  use Monolog\Logger;
  use Monolog\Handler\StreamHandler;
- use Logging\TelegramHandler;
+ use Genesis\RegraNegocio\Logging\TelegramHandler;
  use Psr\Log\LoggerInterface;
 
 trait TraitLogRN

--- a/RegraNegocio/Helpers/TraitRegraNegocio.php
+++ b/RegraNegocio/Helpers/TraitRegraNegocio.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Helpers;
+namespace Genesis\RegraNegocio\Helpers;
 
-use Helpers\TraitLogRN;
+use Genesis\RegraNegocio\Helpers\TraitLogRN;
 use Psr\Log\LoggerInterface;
 
 trait TraitRegraNegocio

--- a/RegraNegocio/Logging/TelegramHandler.php
+++ b/RegraNegocio/Logging/TelegramHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace Logging;
+namespace Genesis\RegraNegocio\Logging;
 
 use Monolog\Logger;
 use Monolog\Handler\AbstractProcessingHandler;

--- a/ValidadorFinanceiro.php
+++ b/ValidadorFinanceiro.php
@@ -1,11 +1,11 @@
 <?php
-namespace App\Rules;
+namespace Genesis\RegraNegocio\App\Rules;
 
-use Genesis\Contracts\BusinessRuleInterface;
-use Genesis\Contracts\LoggableInterface;
+use Genesis\RegraNegocio\IRegraNegocio;
+use Genesis\RegraNegocio\ILog;
 use Psr\Log\LoggerInterface;
 
-class ValidadorFinanceiro implements BusinessRuleInterface, LoggableInterface
+class ValidadorFinanceiro implements IRegraNegocio, ILog
 {
     private array $params = [];
     private LoggerInterface $logger;

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Genesis\\BusinessRules\\": "RegraNegocio/"
+            "Genesis\\RegraNegocio\\": "RegraNegocio/"
         }
     },
     "require": {

--- a/rules/negado_score.php
+++ b/rules/negado_score.php
@@ -1,12 +1,12 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
-use Genesis\RegraNegocio\Helpers\LoggerHelper;
+use Genesis\RegraNegocio\Helpers\TraitLogRN;
 
 $params = json_decode($argv[1] ?? '{}', true);
 
 class NegadoScore {
-    use LoggerHelper;
+    use TraitLogRN;
 }
 
 $log = new NegadoScore();

--- a/rules/validar_idade.php
+++ b/rules/validar_idade.php
@@ -1,13 +1,13 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
-use Genesis\RegraNegocio\Helpers\LoggerHelper;
+use Genesis\RegraNegocio\Helpers\TraitLogRN;
 
 $params = json_decode($argv[1] ?? '{}', true);
 $idade = $params['idade'] ?? null;
 
 class IdadeRule {
-    use LoggerHelper;
+    use TraitLogRN;
 }
 
 $log = new IdadeRule();

--- a/rules/validar_score.php
+++ b/rules/validar_score.php
@@ -1,13 +1,13 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
-use Genesis\RegraNegocio\Helpers\LoggerHelper;
+use Genesis\RegraNegocio\Helpers\TraitLogRN;
 
 $params = json_decode($argv[1] ?? '{}', true);
 $score = $params['score'] ?? null;
 
 class ScoreRule {
-    use LoggerHelper;
+    use TraitLogRN;
 }
 
 $log = new ScoreRule();

--- a/wiki/BusinessRuleInterface.md
+++ b/wiki/BusinessRuleInterface.md
@@ -1,4 +1,4 @@
-# BusinessRuleInterface
+# IRegraNegocio
 
 Interface que define o contrato para qualquer regra de negócio executada no fluxo.
 
@@ -11,4 +11,4 @@ Interface que define o contrato para qualquer regra de negócio executada no flu
 - `hasError()`: indica se houve erro na execução.
 - `getErrors()`: retorna um array de mensagens de erro.
 
-Implementações devem seguir essa interface para que o `BusinessRuleProcessFlow` consiga orquestrar as regras de maneira padronizada.
+Implementações devem seguir essa interface para que o `FluxoRegraNegocio` consiga orquestrar as regras de maneira padronizada.

--- a/wiki/BusinessRuleProcessFlow.md
+++ b/wiki/BusinessRuleProcessFlow.md
@@ -1,6 +1,6 @@
-# BusinessRuleProcessFlow
+# FluxoRegraNegocio
 
-A classe `BusinessRuleProcessFlow` permite organizar e executar regras de negócio de forma sequencial ou condicional. É a porta de entrada para criação de fluxos.
+A classe `FluxoRegraNegocio` permite organizar e executar regras de negócio de forma sequencial ou condicional. É a porta de entrada para criação de fluxos.
 
 ## Métodos principais
 

--- a/wiki/LoggableInterface.md
+++ b/wiki/LoggableInterface.md
@@ -1,4 +1,4 @@
-# LoggableInterface
+# ILog
 
 Interface auxiliar utilizada por classes que precisam disponibilizar um logger.
 

--- a/wiki/LoggerHelper.md
+++ b/wiki/LoggerHelper.md
@@ -1,4 +1,4 @@
-# LoggerHelper
+# TraitLogRN
 
 Trait que provê uma implementação simples de logger utilizando Monolog. Pode ser reutilizada em diferentes regras ou serviços.
 

--- a/wiki/RegraIdade.md
+++ b/wiki/RegraIdade.md
@@ -1,6 +1,6 @@
 # RegraIdade
 
-Exemplo de regra de negócio que valida a idade do usuário. Implementa `BusinessRuleInterface` e `LoggableInterface`.
+Exemplo de regra de negócio que valida a idade do usuário. Implementa `IRegraNegocio` e `ILog`.
 
 ## Exemplo de uso
 


### PR DESCRIPTION
## Summary
- configure autoload for `Genesis\RegraNegocio`
- fix namespaces for helpers, logging and rules
- update example rule scripts
- refresh wiki docs with new class and interface names

## Testing
- `php composer.phar dump-autoload`
- `./vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68509da1cd30832bae6d9b7f69743c0e