### PR TITLE
Add class method execution to business flow

### DIFF
--- a/RegraNegocio/FluxoRegraNegocio.php
+++ b/RegraNegocio/FluxoRegraNegocio.php
@@ -17,14 +17,51 @@ class FluxoRegraNegocio {
 
     public function execute(): void {
         foreach ($this->scripts as $rule) {
-            $result = ['result' => '[simulado]'];
-            if (isset($rule['if']) && $this->params['idade'] < 25) {
+            // Executa regra definida apenas como caminho de script
+            if (is_string($rule)) {
+                $this->result[] = ['executado' => $rule];
+                continue;
+            }
+
+            // Suporte a definicao de classes/metodos
+            if (is_array($rule) && isset($rule['class'])) {
+                $class  = $rule['class'];
+                $method = $rule['method'] ?? 'process';
+                $params = $rule['params'] ?? $this->params;
+
+                if (!class_exists($class)) {
+                    $this->errors[] = "Classe {$class} nao encontrada";
+                    continue;
+                }
+
+                $obj = new $class();
+
+                if (!method_exists($obj, $method)) {
+                    $this->errors[] = "Metodo {$method} nao encontrado em {$class}";
+                    continue;
+                }
+
+                try {
+                    $retorno = $obj->$method($params);
+                    $this->result[] = [
+                        'executado' => "{$class}::{$method}",
+                        'retorno'   => $retorno
+                    ];
+                } catch (\Throwable $e) {
+                    $this->errors[] = $e->getMessage();
+                }
+                continue;
+            }
+
+            // Regra no formato anterior com script condicional
+            if (isset($rule['if']) && ($this->params['idade'] ?? 0) < 25) {
                 $this->errors[] = 'Idade insuficiente';
                 if (isset($rule['else_script'])) {
                     $this->result[] = ['executado' => $rule['else_script']];
                 }
             } else {
-                $this->result[] = ['executado' => is_array($rule) ? $rule['script'] : $rule];
+                $script = $rule['script'] ?? '';
+                $this->result[] = ['executado' => $script];
             }
         }
     }

--- a/tests/ClassMethodExecutionTest.php
+++ b/tests/ClassMethodExecutionTest.php
@@ -1,0 +1,19 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Genesis\RegraNegocio\FluxoRegraNegocio;
+use Genesis\RegraNegocio\App\Rules\MinhaClasse;
+
+class ClassMethodExecutionTest extends TestCase {
+    public function testExecuteMethod() {
+        $flow = new FluxoRegraNegocio();
+        $flow->addRuleScript([
+            'class' => MinhaClasse::class,
+            'method' => 'minhaValidacao',
+            'params' => ['idade' => 20]
+        ]);
+        $flow->execute();
+        $this->assertFalse($flow->hasError());
+        $result = $flow->getResult();
+        $this->assertEquals(['validacao' => 'Idade aceita'], $result[0]['retorno']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `FluxoRegraNegocio::execute` to run class methods
- cover new behaviour with a test

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6850a9e5e4c4832ba63610fff3719ed5